### PR TITLE
Refactor add_to_span to use switch instead of if-else

### DIFF
--- a/main.c
+++ b/main.c
@@ -609,36 +609,38 @@ void add_to_span(struct span *s, int letter)
 		case 0x2500: /* Box drawings light horizontal */
 		case 0x2501: /* Box drawings heavy horizontal */
 			letter = '-';
-
+			break;
 		case 0x2502: /* Box drawings light vertical */
 		case 0x2503: /* Box drawings heavy vertical */
 			letter = '|';
-
+			break;
 		case 0x2002: /* En space */
 			letter = ' ';
+			break;
 		case 0x2265: /* Greater than or equal */
 			{
 				letter = '>';
 				letter_2 = '=';
 			}
-
+			break;
 		case 0x2264: /* Less than or equal */
 			{
 				letter = '<';
 				letter_2 = '=';
 			}
-
+			break;
 		case 160: /* Non-breaking space */
 			letter = ' ';
 
+			break;
 		case 0x201c:
 		case 0x201d: /* Left and right double quotation mark */
 			letter = '"';
-
+			break;
 		case 0x2018:
 		case 0x2019: /* Left and right single quotation mark */
 			letter = '\'';
-
+			break;
 	}
 
 	if ((letter >= 0x250c) && (letter <= 0x254b))

--- a/main.c
+++ b/main.c
@@ -597,42 +597,54 @@ struct span* get_last_span(struct manpage *p)
 void add_to_span(struct span *s, int letter)
 {
 #define STARTING_SPAN_SIZE 32
-    char letter_2 = 0;
+	char letter_2 = 0;
 
-    if ((letter >= 0x2500) && (letter <= 0x2501))
-        letter = '-';
-    else if ((letter >= 0x2502) && (letter <= 0x2503))
-        letter = '|';
-    else if ((letter >= 0x250c) && (letter <= 0x254b)) /* various cross symbols */
-        letter = '+';
-    else if (letter == 0x2014)
-        letter = '-';
-    else if (letter == 0x2212)
-        letter = '-';
-    else if (letter == 0x2002)
-        letter = ' ';
-    else if (letter == 0x2010)
-        letter = '-';
-    else if (letter == 0x2013) /* en dash */
-        letter = '-';
-    else if (letter == 0x2022) /* bullet */
-        letter = '-';
-    else if (letter == 0x2265) /* greater than or equel */
-    {
-        letter = '>';
-        letter_2 = '=';
-    }
-    else if (letter == 0x2264) /* less than or equel */
-    {
-        letter = '<';
-        letter_2 = '=';
-    }
-    else if (letter == 160) /* non breaking space */
-        letter = ' ';
-    else if ((letter == 0x201c) || (letter == 0x201d)) /* left and right double quotation mark */
-        letter = '"';
-    else if ((letter == 0x2018) || (letter == 0x2019)) /* left and right single quotation mark */
-        letter = '\'';
+	switch(letter)
+	{
+		case 0x2010: /* Hyphen */
+		case 0x2013: /* En dash */
+		case 0x2014: /* Em dash */
+		case 0x2022: /* Bullet */
+		case 0x2212: /* Minus sign */
+		case 0x2500: /* Box drawings light horizontal */
+		case 0x2501: /* Box drawings heavy horizontal */
+			letter = '-';
+
+		case 0x2502: /* Box drawings light vertical */
+		case 0x2503: /* Box drawings heavy vertical */
+			letter = '|';
+
+		case 0x2002: /* En space */
+			letter = ' ';
+		case 0x2265: /* Greater than or equal */
+			{
+				letter = '>';
+				letter_2 = '=';
+			}
+
+		case 0x2264: /* Less than or equal */
+			{
+				letter = '<';
+				letter_2 = '=';
+			}
+
+		case 160: /* Non-breaking space */
+			letter = ' ';
+
+		case 0x201c:
+		case 0x201d: /* Left and right double quotation mark */
+			letter = '"';
+
+		case 0x2018:
+		case 0x2019: /* Left and right single quotation mark */
+			letter = '\'';
+
+	}
+
+	if ((letter >= 0x250c) && (letter <= 0x254b))
+	{
+		letter = '+';	 /* various cross symbols */
+	}
 
     if (letter < 256)
     {


### PR DESCRIPTION
This commits refactors the add_to_span function. Using a switch case makes it a bit more readable and possibly performant since it uses fallthroughs. I've added comments for each character as well. 