### PR TITLE
Fix mandoc -Tlint warnings.

### DIFF
--- a/mangl.1
+++ b/mangl.1
@@ -17,7 +17,8 @@ and smooth scrolling.
 .Sh MANGL STARTUP FILE
 The
 .Ar .manglrc
-file may contain configuration options.  The defaults are
+file may contain configuration options.
+The defaults are
 .Bd -literal -offset indent
 font: Anonymous Pro
 font_size: 10
@@ -40,7 +41,8 @@ color_searches: #1515ff
 color_search_selected: #15ff15
 .Ed
 font parameter uses the fc-match external program to find the font
-file. The font file can also be specified directly.
+file.
+The font file can also be specified directly.
 .Sh KEYBOARD AND MOUSE COMMANDS
 .Bl -tag -width Ds
 .It Cm j
@@ -69,8 +71,8 @@ Exit the program.
 Search for the string
 .Dq text
 in the file,
-and move the cursor to its first character.  Case insensitive
-unless text is mixed-case.
+and move the cursor to its first character.
+Case insensitive unless text is mixed-case.
 .It Cm n, N
 Move to the next (N:previous) location of text.
 .El


### PR DESCRIPTION
Hi --

This PR fixes the warnings introduced in #10.
`mandoc -Tlint` will ensure that manual pages are correct.

Thanks!