### PR TITLE
Remove dummy global variables

### DIFF
--- a/mandoc/compat_err.c
+++ b/mandoc/compat_err.c
@@ -2,7 +2,6 @@
 
 #if HAVE_ERR
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_fts.c
+++ b/mandoc/compat_fts.c
@@ -2,7 +2,6 @@
 
 #if HAVE_FTS
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_getline.c
+++ b/mandoc/compat_getline.c
@@ -2,7 +2,6 @@
 
 #if HAVE_GETLINE
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_getsubopt.c
+++ b/mandoc/compat_getsubopt.c
@@ -2,7 +2,6 @@
 
 #if HAVE_GETSUBOPT
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_isblank.c
+++ b/mandoc/compat_isblank.c
@@ -2,7 +2,6 @@
 
 #if HAVE_ISBLANK
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_mkdtemp.c
+++ b/mandoc/compat_mkdtemp.c
@@ -2,7 +2,6 @@
 
 #if HAVE_MKDTEMP
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_ohash.c
+++ b/mandoc/compat_ohash.c
@@ -2,7 +2,6 @@
 
 #if HAVE_OHASH
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_progname.c
+++ b/mandoc/compat_progname.c
@@ -2,7 +2,6 @@
 
 #if HAVE_PROGNAME
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_reallocarray.c
+++ b/mandoc/compat_reallocarray.c
@@ -2,7 +2,6 @@
 
 #if HAVE_REALLOCARRAY
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_recallocarray.c
+++ b/mandoc/compat_recallocarray.c
@@ -2,7 +2,6 @@
 
 #if HAVE_RECALLOCARRAY
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_strcasestr.c
+++ b/mandoc/compat_strcasestr.c
@@ -2,7 +2,6 @@
 
 #if HAVE_STRCASESTR
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_stringlist.c
+++ b/mandoc/compat_stringlist.c
@@ -2,7 +2,6 @@
 
 #if HAVE_STRINGLIST
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_strlcat.c
+++ b/mandoc/compat_strlcat.c
@@ -2,7 +2,6 @@
 
 #if HAVE_STRLCAT
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_strlcpy.c
+++ b/mandoc/compat_strlcpy.c
@@ -2,7 +2,6 @@
 
 #if HAVE_STRLCPY
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_strndup.c
+++ b/mandoc/compat_strndup.c
@@ -2,7 +2,6 @@
 
 #if HAVE_STRNDUP
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_strsep.c
+++ b/mandoc/compat_strsep.c
@@ -2,7 +2,6 @@
 
 #if HAVE_STRSEP
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_strtonum.c
+++ b/mandoc/compat_strtonum.c
@@ -2,7 +2,6 @@
 
 #if HAVE_STRTONUM
 
-int dummy;
 
 #else
 

--- a/mandoc/compat_vasprintf.c
+++ b/mandoc/compat_vasprintf.c
@@ -2,7 +2,6 @@
 
 #if HAVE_VASPRINTF
 
-int dummy;
 
 #else
 


### PR DESCRIPTION
The global variable called `dummy` is defined multiple times, if multiple libraries are found in the configure step. The variable does not seem to be necessary anyway, so this pull request just removes it, so that the program compiles again.

This would fix  #12.