### PR TITLE
add a configure script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,10 @@ libraries). On Debian systems run:
 sudo apt install pkg-config libz-dev libgl-dev libglfw3-dev libfreetype6-dev
 ```
 
-First run `./configure` in mandoc folder:
+Then, run the usual
 
 ```
-cd mandoc
 ./configure
-```
-
-Then run `make` in root folder:
-
-```
-cd ..
 make
 ```
 

--- a/configure
+++ b/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cd mandoc && ./configure "$@"


### PR DESCRIPTION
This makes easier to package mangl, and hopefully makes the life easier also to user that builds mangl by hand.

I'm adding a simple configure script that just execute mandoc' ones, so one only needs to do the usual `./configure && make`.  It also propagates the arguments given (unlike `build.sh`), so that users and packagers can pass arguments to mandoc' configure if needed.