### PR TITLE
Use getopt_long to parse the options

### DIFF
--- a/mangl.1
+++ b/mangl.1
@@ -7,13 +7,27 @@
 .Nd graphical man page viewer
 .Sh SYNOPSIS
 .Nm mangl
-.Op section
-.Op manpage
+.Op Fl fhlV
+.Op Oo Ar section Oc Ar page
 .Sh DESCRIPTION
 The
 .Nm
 utility uses OpenGL to display man pages with clickable hyperlinks
 and smooth scrolling.
+.Pp
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl f , Fl -no-fork
+Don't fork the GUI in the background.
+.It Fl h , Fl -help
+Show the usage and quit.
+.It Fl l , Fl -local-file
+Interpret
+.Ar page
+as a local filename.
+.It Fl V , Fl -version
+Print the version and quit.
+.El
 .Sh MANGL STARTUP FILE
 The
 .Ar .manglrc


### PR DESCRIPTION
This PR switches the main to use getopt_long for parsing the flags given on the command line.  Using getopt(3) or getopt_long(3) should be preferred over manually parsing, as they already cover a lot of edge cases.

While here I also couldn't resist the temptation to add a single letter version for the long flags and mention the flags in the manpage too.