### PR TITLE
improve the `install' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,12 @@ mangl: $(COMPAT_OBJS) $(LIBMANDOC_OBJS) $(MANGL_SOURCES)
 sanitizer: CFLAGS += -fsanitize=address
 sanitizer: mangl
 
-MANDIR=/usr/local/share/man
-
 .PHONY: install
 install: mangl
-	cp mangl /usr/local/bin/
-	mkdir -p ${MANDIR}/man1
-	cp mangl.1 ${MANDIR}/man1/
-	chmod 644 ${MANDIR}/man1/mangl.1
+	mkdir -p ${DESTDIR}${BINDIR}
+	mkdir -p ${DESTDIR}${MANDIR}/man1
+	${INSTALL_PROGRAM} mangl ${DESTDIR}${BINDIR}
+	${INSTALL_MAN} mangl.1 ${DESTDIR}${MANDIR}/man1/
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
- don't re-define MANDIR
- respect ${DESTDIR}
- use INSTALL_* instead of cp (+ chmod)

MANDIR, BINDIR, INSTALL_PROGRAM, INSTALL_MAN & co are provided by `mandoc/Makefile.local`, DESTDIR is usually specified by the packager.  Packages infrastructure often do install the content of a package in a temporary directory from which the package is then produced.