### PR TITLE
main.c: use apple gl.h on macos

### DIFF
--- a/main.c
+++ b/main.c
@@ -22,7 +22,12 @@
 #include <err.h>
 #include <stdbool.h>
 #include <ctype.h>
+#ifndef __APPLE__
 #include <GL/gl.h>
+#endif
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#endif
 #include <GLFW/glfw3.h>
 
 #include "ft2build.h"


### PR DESCRIPTION
This at least allows it to build, although display isnt working, so that still needs some figuring out. eg. `./mangl -f man` gives an empty black window with the titlebar `man(1) - mangl`, so some stuff is working. Tons of deprecated warnings on build too.

To install the dependencies with [homebrew](https://brew.sh/) is: `brew install zlib glfw freetype`

