### PR TITLE
fix fractional scaling

### DIFF
--- a/main.c
+++ b/main.c
@@ -1217,7 +1217,7 @@ void window_refresh_func(GLFWwindow *window)
     redisplay_needed = true;
 }
 
-void window_size_func(GLFWwindow *window, int w, int h)
+void framebuffer_size_func(GLFWwindow *window, int w, int h)
 {
     window_width = w;
     window_height = h;
@@ -3458,7 +3458,7 @@ int main(int argc, char *argv[])
     glfwMakeContextCurrent(window);
 
     // For fractional scaling purposes *window size* and *framebuffer size* are different.
-    glfwSetFramebufferSizeCallback(window, window_size_func);
+    glfwSetFramebufferSizeCallback(window, framebuffer_size_func);
     glfwSetWindowRefreshCallback(window, &window_refresh_func);
 
     glfwSetMouseButtonCallback(window, &mouse_button_func);
@@ -3477,7 +3477,7 @@ int main(int argc, char *argv[])
     int w = 0;
     int h = 0;
     glfwGetFramebufferSize(window, &w, &h);
-    window_size_func(window, w, h);
+    framebuffer_size_func(window, w, h);
     redisplay_needed = true;
 
     while (!glfwWindowShouldClose(window))

--- a/main.c
+++ b/main.c
@@ -3457,7 +3457,8 @@ int main(int argc, char *argv[])
 
     glfwMakeContextCurrent(window);
 
-    glfwSetWindowSizeCallback(window, &window_size_func);
+    // For fractional scaling purposes *window size* and *framebuffer size* are different.
+    glfwSetFramebufferSizeCallback(window, window_size_func);
     glfwSetWindowRefreshCallback(window, &window_refresh_func);
 
     glfwSetMouseButtonCallback(window, &mouse_button_func);
@@ -3469,9 +3470,13 @@ int main(int argc, char *argv[])
 
     upload_font_textures();
 
+    // Hacky but required in the case of fractional scaling since for
+    // whatever reason the scale isn't known until the first buffer swap.
+    glfwSwapBuffers(window);
+
     int w = 0;
     int h = 0;
-    glfwGetWindowSize(window, &w, &h);
+    glfwGetFramebufferSize(window, &w, &h);
     window_size_func(window, w, h);
     redisplay_needed = true;
 


### PR DESCRIPTION
When a system's fractional scaling is set to any value other than 1, glfwGetWindowSize and glfwGetFramebufferSize disagree (in fact I think glfwGetWindowSize even includes window decorations so it's extra incorrect but I'm not 100% sure). This pull request uses the correct size function and renames the callback to better reflect what is actually happening.

Another fix is calling glfwSwapBuffers() before getting the framebuffer size for the first time, as on some systems for whatever reason it doesn't report the correct size until after the first paint. An unfortunate but seemingly necessary workaround unless there's obviously a better way.

Thanks,
Aaron.