### PR TITLE
fix null pointer dereference when handling allocation failure

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -61,7 +61,7 @@ static void clear_element(hashmap_element *el)
  */
 map_t hashmap_new()
 {
-    hashmap_map* m = (hashmap_map*) malloc(sizeof(hashmap_map));
+    hashmap_map* m = (hashmap_map*)calloc(1, sizeof(hashmap_map));
     if(!m) goto err;
 
     m->data = (hashmap_element*)calloc(INITIAL_SIZE, sizeof(hashmap_element));


### PR DESCRIPTION
When the `malloc` call in `hashmap_new` succeeded but then the later `calloc` call failed, the error logic would call `hashmap_free` that would dereference `m->data`. This occurred because `m->table_size` is not yet set and likely contains a non-zero value, despite `m->data == NULL`. This change avoids the situation by zeroing the initial memory, including `m->table_size`.